### PR TITLE
🔧 fix: update post listing layout to allow tags to wrap

### DIFF
--- a/src/components/PostListing.jsx
+++ b/src/components/PostListing.jsx
@@ -34,7 +34,7 @@ const PostListing = ({post, postId, handleFilterPush, handleRemove}) => {
             <div className='flex flex-col lg:text-left lg:ml-0 gap-2 max-w-2/3 mt-2'>
                 <Link to={'/posts/' + postId} className='w-auto'><p className='text-2xl font-bold mt-2'>{post.title}</p></Link>
                 <Link to={'/posts/' + postId} className='w-auto'><p className='text-sm italic border-l-2 pl-2 border-neutral-500 text-neutral-600 dark:text-neutral-400'>{post.subtitle}</p></Link>
-                <div className='flex flex-row gap-2 mt-2 justify-start'>
+                <div className='flex flex-row flex-wrap gap-2 mt-2 justify-start'>
                     {post.tags.map((tag, i) => {
                         return <Tag text={tag} handleClick={handleFilterPush} key={i} className='hover:tag-invert'/>
                     })}


### PR DESCRIPTION
🔧 fix: update post listing layout to allow tags to wrap when exceeding width. fixes #31.