### PR TITLE
AuthLoaded & Spinner vs. Loading

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -64,7 +64,7 @@ const routes = [
     {name: 'Log Out', ref: createRef(), path: '/log-out', Component: PrivateRoute, children: [{path: '/log-out', Component: LogOut}]},
     {name: 'Profile', ref: createRef(), path: '/profile/:userId', Component: PrivateRoute, children: [{path: '/profile/:userId', Component: Profile}]},
     {name: 'New Post', ref: createRef(), path: '/new-post', Component: PrivateRoute, children: [{ path: '/new-post', Component: PostForm }]},
-    {name: 'Posts', ref: createRef(), path: '/posts', Component: PrivateRoute, children: [{ path: '/posts', Component: Posts }]},
+    {name: 'Posts', ref: createRef(), path: '/posts', Component: Posts },
     {name: 'Post', ref: createRef(), path: '/posts/:postId', Component: Post},
     {name: 'Title Notes', ref: createRef(), path: '/title-notes', Component: TitleNotes},
     {name: 'Title Notes App', ref: createRef(), path: '/title', Component: () => <Redirect to='https://titlenotes.netlify.app/'></Redirect>},

--- a/src/components/Loading.jsx
+++ b/src/components/Loading.jsx
@@ -1,0 +1,11 @@
+import spinner from '../assets/spinner.gif'
+
+const Spinner = () => {
+    return (
+        <div>
+            <img src={spinner} alt="loading" style={{height: '16px', width: '16px'}} />
+        </div>
+    );
+};
+
+export default Spinner;

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,44 +1,37 @@
-import {useEffect, useState} from 'react';
-import {Link, useLocation, useNavigate} from "react-router-dom";
-import {getAuth, onAuthStateChanged} from "firebase/auth";
+import {useContext} from 'react';
+import {Link, useLocation} from "react-router-dom";
+import spinner from '../assets/spinner.gif'
 import '../styles/Navbar.css'
 import { BsDoorOpenFill, BsGithub, BsKeyFill } from 'react-icons/bs';
+import { AuthContext } from '../context/AuthProvider';
 
 const Navbar = () => {
 
     const location = useLocation();
-    const navigate = useNavigate();
-    const [loggedIn, setLoggedIn] = useState(false);
-    const auth = getAuth();
-
-    useEffect(() => {
-        onAuthStateChanged(auth, (user) => {
-            if(user){
-                setLoggedIn(true)
-            } else {
-                setLoggedIn(false)
-            }
-        })
-    })
+    const {currentUser, authLoaded} = useContext(AuthContext);
 
     return (
         <div className='fixed top-0 z-10 bg-white dark:bg-black w-full' style={{maxWidth: '100vw'}}>
-            <nav className='h-8 flex mx-4 lg:mx-8 mt-8 text-black dark:text-white gap-2 text-md'>
-                <Link to="/" className={`navbar-link ${location.pathname === '/' && 'current'}`}>Home</Link>
+            <nav className='h-8 flex mx-2 sm:mx-4 lg:mx-8 mt-6 text-black dark:text-white gap-2 text-md'>
+                <Link to="/" className={`navbar-link font-bold  ${location.pathname === '/' && 'current'}`}>Chris Yates</Link>
                 <Link to="/resume" className={`navbar-link ${location.pathname === '/resume' && 'current'}`}>Resume</Link>
                 <Link to="/contact" className={`navbar-link ${location.pathname === '/contact' && 'current'}`}>Contact</Link>
-                {loggedIn  && (
-                    <Link to="/posts" className={`navbar-link ${location.pathname === '/posts' && 'current'}`}>Posts</Link>
-                )}
-                {loggedIn ? (
-                    <Link to="/log-out" className={`navbar-link endcap ${location.pathname === '/log-out' && 'current'}`} >
-                        <BsDoorOpenFill />
-                    </Link>
-                ) : (
-                    <Link to="/log-in" className={`navbar-link endcap ${location.pathname === '/log-in' && 'current'}`} >
-                        <BsKeyFill />
-                    </Link>
-                )}
+                <Link to="/posts" className={`navbar-link ${location.pathname === '/posts' && 'current'}`}>Posts</Link>
+                {authLoaded ? 
+                    (currentUser ? (
+                        <Link to="/log-out" className={`navbar-link endcap ${location.pathname === '/log-out' && 'current'}`} >
+                            <BsDoorOpenFill />
+                        </Link>
+                    ) : (
+                        <Link to="/log-in" className={`navbar-link endcap ${location.pathname === '/log-in' && 'current'}`} >
+                            <BsKeyFill />
+                        </Link>
+                    )) : ( 
+                        <Link to="/log-in" className={`navbar-link endcap pt-1 ${location.pathname === '/log-in' && 'current'}`} >
+                            <img src={spinner} alt="loading" style={{height: '14.4px', width: '14.4px'}} />
+                        </Link>
+                    )
+                }
                 <a href="https://github.com/totalchris/" className={`navbar-link endcap ${location.pathname === '#' && 'current'}`}>
                     <BsGithub />
                 </a>

--- a/src/components/PageScaffold.jsx
+++ b/src/components/PageScaffold.jsx
@@ -1,6 +1,6 @@
 export default function PageScaffold({ children, extras }) {
   return (
-    <div className={ `mx-4 lg:mx-auto pt-24 lg:px-8 min-h-full max-w-screen col:max-w-screen-col ${extras}` }>
+    <div className={ `mx-4 lg:mx-auto py-24 lg:px-8 min-h-full max-w-screen col:max-w-screen-col ${extras}` }>
         {children}    
     </div>
   )

--- a/src/components/PostListing.jsx
+++ b/src/components/PostListing.jsx
@@ -5,7 +5,8 @@ import Tag from "./Tag";
 import {getAuth} from 'firebase/auth';
 import {doc, deleteDoc, updateDoc} from 'firebase/firestore'
 import {BsGlobe, BsPerson} from 'react-icons/bs'
-import Spinner from './Spinner'
+import Loading from "../components/Loading"
+
 const PostListing = ({post, postId, handleFilterPush, handleRemove}) => {
 
     const dateFormatter = Intl.DateTimeFormat("en-US", {month: 'long', day: 'numeric', year: "numeric"})
@@ -42,8 +43,8 @@ const PostListing = ({post, postId, handleFilterPush, handleRemove}) => {
                 <div className='flex flex-row justify-between text-md text-neutral-500'>{dateFormatter.format(post.timestamp.toDate())}{post.isPrivate?<BsPerson className="text-xl"></BsPerson>:<BsGlobe className="text-xl"></BsGlobe>}</div>
             </div>
             {getAuth().currentUser ? <div className='flex flex-row mt-4 w-full justify-between'>
-                <button type="button" onClick={changePostVisibility} className="mr-2 btn btn-primary dark:text-black dark:bg-white dark:hover:text-black dark:hover:bg-white rounded-xl hover:cursor-pointer border-none w-44 grow">{pendingChange ? <Spinner /> : 'Make ' + (post.isPrivate ? 'Public' : 'Private' )}</button>
-                <button type="button" onClick={deletePost} className="ml-2 btn btn-outline dark:text-white dark:border-white dark:hover:text-black dark:hover:bg-white rounded-xl hover:cursor-pointer w-44 grow">{pendingDelete ? <Spinner /> : 'Delete'}</button>
+                <button type="button" onClick={changePostVisibility} className="mr-2 btn btn-primary dark:text-black dark:bg-white dark:hover:text-black dark:hover:bg-white rounded-xl hover:cursor-pointer border-none grow">{pendingChange ? <Loading /> : 'Make ' + (post.isPrivate ? 'Public' : 'Private' )}</button>
+                <button type="button" onClick={deletePost} className="ml-2 btn btn-outline dark:text-white dark:border-white dark:hover:text-black dark:hover:bg-white rounded-xl hover:cursor-pointer grow">{pendingDelete ? <Loading /> : 'Delete'}</button>
             </div> : <></>}
         </div>
     );

--- a/src/components/PrivateRoute.jsx
+++ b/src/components/PrivateRoute.jsx
@@ -1,11 +1,23 @@
 import { Outlet } from "react-router-dom";
 import { AuthContext } from "../context/AuthProvider";
-import { useContext } from "react";
+import { useContext, useEffect, useState } from "react";
 import LogIn from "../pages/LogIn";
+import Spinner from "./Loading";
 
 const PrivateRoute = () => {
 
-    const { currentUser } = useContext(AuthContext);
+    const { currentUser, authLoaded } = useContext(AuthContext);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        if(authLoaded){
+            setLoading(false);
+        }
+    }, [authLoaded])
+
+    if(loading){
+        return <Spinner />
+    }
 
     return (currentUser ? <Outlet /> : <LogIn />)
 };

--- a/src/components/Redirect.jsx
+++ b/src/components/Redirect.jsx
@@ -1,5 +1,5 @@
-import React, {useEffect} from 'react';
-import Spinner from "./Spinner";
+import {useEffect} from 'react';
+import Spinner from "../pages/Spinner";
 
 const Redirect = ({to}) => {
 

--- a/src/context/AuthProvider.jsx
+++ b/src/context/AuthProvider.jsx
@@ -5,14 +5,18 @@ export const AuthContext = createContext();
 
 export const AuthProvider = ({ children }) => {
 
-    const [currentUser, setCurrentUser] = useState(null);
+    const [currentUser, setCurrentUser] = useState(undefined);
+    const [authLoaded, setAuthLoaded] = useState(false);
 
     useEffect(() => {
-        auth.onAuthStateChanged(setCurrentUser)
-    }, [])
+        auth.onAuthStateChanged(setCurrentUser);
+        if(currentUser !== undefined){
+            setAuthLoaded(true);
+        }
+    }, [currentUser])
 
     return (
-        <AuthContext.Provider value={{currentUser}}>
+        <AuthContext.Provider value={{currentUser, authLoaded}}>
             { children }
         </AuthContext.Provider>
     )

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -1,7 +1,7 @@
 import {useState} from 'react';
 import { useForm, ValidationError } from '@formspree/react';
 import {useNavigate} from "react-router-dom";
-import Spinner from "../components/Spinner";
+import Loading from "../components/Loading";
 import { Link } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 import PageScaffold from '../components/PageScaffold';
@@ -68,7 +68,7 @@ const Contact = () => {
                         Your information isn&apos;t complete. Try again.
                     </div>
                     <button type='submit' disabled={formState.submitting} className='ml-auto btn-wire'>
-                        {formState.submitting ? <Spinner /> : 'Send'}
+                        {formState.submitting ? <Loading /> : 'Send'}
                     </button>
                 </div>
             </form>

--- a/src/pages/LogIn.jsx
+++ b/src/pages/LogIn.jsx
@@ -1,15 +1,29 @@
-import {useState} from 'react';
+import {useContext, useEffect, useState} from 'react';
 import {useLocation, useNavigate} from "react-router-dom";
 import {getAuth, setPersistence, signInWithEmailAndPassword, browserLocalPersistence} from 'firebase/auth'
 import PageScaffold from '../components/PageScaffold';
+import { AuthContext } from '../context/AuthProvider';
 const LogIn = () => {
 
     const navigate = useNavigate();
-    const [formData, setFormData] = useState({email: '', password: ''});
     const location = useLocation();
+
+    const [formData, setFormData] = useState({email: '', password: ''});
     const [error, setError] = useState(false);
 
+    const {currentUser, authLoaded} = useContext(AuthContext)
+
     const {email, password} = formData;
+
+    useEffect(() => {
+        if(authLoaded && currentUser){
+            if(location.pathname !== '/log-in'){
+                navigate(location.pathname)
+            } else {
+                navigate('/');
+            }
+        }
+    }, [authLoaded, currentUser])
 
     const handleChange = (e) => {
         setFormData((prevState) => {
@@ -19,20 +33,14 @@ const LogIn = () => {
             }
         })
     }
+
     const handleSubmit = async (e) => {
         e.preventDefault();
         setError(false);
         try{
             const auth = getAuth();
             await setPersistence(auth, browserLocalPersistence)
-            const userCredential = await signInWithEmailAndPassword(auth, email, password);
-            if (userCredential.user) {
-                if(location.pathname !== '/log-in'){
-                    navigate(location.pathname)
-                } else {
-                    navigate('/');
-                }
-            }
+            await signInWithEmailAndPassword(auth, email, password);
         } catch(e) {
             console.log(e);
             setError(true);

--- a/src/pages/Post.jsx
+++ b/src/pages/Post.jsx
@@ -2,7 +2,7 @@ import {useEffect, useState, useContext} from 'react';
 import {useParams, useNavigate, Link} from "react-router-dom";
 import {doc, getDoc} from "firebase/firestore";
 import {db} from "../firebase.config";
-import Spinner from "../components/Spinner";
+import Spinner from "./Spinner";
 import ReactMarkdown from "react-markdown";
 import {Helmet, HelmetProvider} from "react-helmet-async";
 import Chris from "../assets/carousel/Chris-07.webp";
@@ -14,7 +14,7 @@ const Post = () => {
 
     const params = useParams();
     const navigate = useNavigate();
-    const {currentUser} = useContext(AuthContext)
+    const {currentUser, authLoaded} = useContext(AuthContext)
 
     const [loading, setLoading] = useState(true);
     const [post, setPost] = useState({});
@@ -22,18 +22,19 @@ const Post = () => {
     const dateFormatter = Intl.DateTimeFormat("en-US", {month: 'long', day: 'numeric', year: "numeric"})
 
     useEffect(() => {
-        fetchPost().then();
+        if(authLoaded){
+            fetchPost().then();
+        }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [])
+    }, [authLoaded])
 
     const fetchPost = async () => {
-
         const postRef = await getDoc(doc(db, 'posts', params.postId));
-        if(postRef.exists() && (!postRef.data().isPrivate || (postRef.data().isPrivate && currentUser))){
+        if(postRef.exists() && (!postRef.data().isPrivate || (postRef.data().isPrivate && (currentUser)))){
             setPost(postRef.data());
             setLoading(false);
         } else {
-            navigate('/not-found')
+            navigate('/not-found');
         }
     }
 

--- a/src/pages/PostForm.jsx
+++ b/src/pages/PostForm.jsx
@@ -5,7 +5,7 @@ import {setDoc, doc, serverTimestamp} from 'firebase/firestore'
 import { getStorage, ref, uploadBytes, getDownloadURL } from "firebase/storage";
 import {db} from "../firebase.config";
 import {useNavigate} from "react-router-dom";
-import Spinner from "../components/Spinner";
+import Loading from "../components/Loading";
 import MarkdownIt from 'markdown-it';
 import MdEditor from 'react-markdown-editor-lite';
 import 'react-markdown-editor-lite/lib/index.css';
@@ -127,7 +127,7 @@ const PostForm = () => {
                     </div>
                 ) )}
                 <button type='submit' className={'ml-auto btn-wire mt-8 min-h-fit' + (loading && 'btn-disabled')}>
-                    {loading ? <Spinner /> : 'Submit'}
+                    {loading ? <Loading /> : 'Submit'}
                 </button>
             </form>
         </PageScaffold>

--- a/src/pages/Posts.jsx
+++ b/src/pages/Posts.jsx
@@ -1,6 +1,6 @@
 import {useCallback, useEffect, useRef, useState} from 'react';
 import {collection, query, getDocs, orderBy, where} from 'firebase/firestore'
-import Spinner from "../components/Spinner";
+import Spinner from "./Spinner";
 import {db} from "../firebase.config";
 import {BsSortDown, BsSortUpAlt} from "react-icons/bs";
 import PostListing from "../components/PostListing";

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -4,7 +4,7 @@ import {useNavigate, useParams} from "react-router-dom";
 import {db} from '../firebase.config'
 import {getAuth} from "firebase/auth";
 import {collection, getDocs, query, where, orderBy} from "firebase/firestore";
-import Spinner from "../components/Spinner";
+import Spinner from "./Spinner";
 import PostListing from "../components/PostListing";
 import Tag from '../components/Tag';
 import {BsSortUpAlt, BsSortDown} from 'react-icons/bs'

--- a/src/pages/Resume.jsx
+++ b/src/pages/Resume.jsx
@@ -1,6 +1,6 @@
 import {useCallback, useEffect, useRef, useState} from 'react';
 import JobEntry from "../components/JobEntry";
-import Spinner from "../components/Spinner";
+import Spinner from "./Spinner";
 import {BsSortDown, BsSortUpAlt} from "react-icons/bs";
 import Tag from "../components/Tag";
 import tn from "../assets/projectAssets/tn.png"

--- a/src/pages/Spinner.jsx
+++ b/src/pages/Spinner.jsx
@@ -1,9 +1,8 @@
-import React from 'react';
 import spinner from '../assets/spinner.gif'
 
 const Spinner = () => {
     return (
-        <div className='flex justify-center items-center h-96'>
+        <div className='flex justify-center items-center h-96 w-full'>
             <img src={spinner} height="64px" width="64px" alt="loading" style={{height: '64px', width: '64px'}} />
         </div>
     );

--- a/src/styles/Navbar.css
+++ b/src/styles/Navbar.css
@@ -12,14 +12,21 @@ nav{
 }
 
 a.navbar-link{
-    font-size: 1rem;
     height: inherit;
-    padding-inline: .5rem;
-    align-content: center;
+    margin-inline: .25rem;
+    align-content: flex-start;
     color: var(--primary);
     text-decoration: none;
     border-bottom: 1px solid transparent;
     transition: border-bottom .2s ease-in-out;
+}
+
+a.navbar-link:first-child{
+    margin-left: 0;
+}
+
+a.navbar-link:last-child{
+    margin-right: 0;
 }
 
 a.navbar-link:has(svg){


### PR DESCRIPTION
- Add AuthLoaded prop to AuthContext to determine if pages are ready to decide on prompting a login or loading content. This will cut down on the number of auth problems I'm having and ensure each component has a safe way to check auth status and time content loads.
- With the introduction of AuthLoaded, Posts is now public again as I can control the visibility of my posts when logged in. Also solves https://github.com/TotalChris/portfolio/issues/27.
- Separated the Spinner component into a new boxed component called Loading. Spinner is now a page with page scaffolding attached. All references to Spinner in buttons and smaller contexts have been replaced with Loading, and all pages using Spinner for their intermediate states now look nicer. Solves https://github.com/TotalChris/portfolio/issues/33.
- Made "Home" text in the Navbar a bolded name to communicate site title and subject.