### PR TITLE
Hide scrollbars in transitionary states

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -26,3 +26,7 @@
 	opacity: 0;
 	transition: filter .25s, opacity .25s, transform .25s;
 }
+
+body:has(.route-enter-active), body:has(.route-exit-active){
+	overflow: hidden;
+}


### PR DESCRIPTION
This commit adds an `overflow: hidden` to the *-active states of the CSSTranstion on my page root. This fixes #40.